### PR TITLE
Allow larger json payloads

### DIFF
--- a/CalendarToSlack/CalendarToSlack.csproj
+++ b/CalendarToSlack/CalendarToSlack.csproj
@@ -55,6 +55,10 @@
       <HintPath>..\packages\Microsoft.Exchange.WebServices.2.2\lib\40\Microsoft.Exchange.WebServices.Auth.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web.Helpers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/CalendarToSlack/Http/HttpServer.cs
+++ b/CalendarToSlack/Http/HttpServer.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Web.Helpers;
 using log4net;
+using Newtonsoft.Json;
 
 namespace CalendarToSlack.Http
 {
@@ -120,7 +121,7 @@ namespace CalendarToSlack.Http
                     if (response.IsSuccessStatusCode)
                     {
                         var responseContent = response.Content.ReadAsStringAsync().Result;
-                        var json = Json.Decode(responseContent);
+                        var json = (dynamic)JsonConvert.DeserializeObject(responseContent);
 
                         if (!json.ok)
                         {

--- a/CalendarToSlack/Program.cs
+++ b/CalendarToSlack/Program.cs
@@ -70,6 +70,11 @@ namespace CalendarToSlack
 
         private static Dictionary<Config, string> LoadConfig(string path)
         {
+            // ensure file exists
+            if (!File.Exists(path))
+            {
+                throw new ApplicationException("A config file at '" + path + "' was not found. See https://github.com/robhruska/CalendarToSlack/wiki/Installing for instructions on setting up this slackbot");
+            }
             var lines = File.ReadAllLines(path);
             return lines.Where(line => !line.StartsWith("#")).ToDictionary(line => (Config) Enum.Parse(typeof(Config), line.Split('=')[0]), line => line.Split('=')[1]);
         }

--- a/CalendarToSlack/Slack.cs
+++ b/CalendarToSlack/Slack.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Web.Helpers;
 using log4net;
+using Newtonsoft.Json;
 
 namespace CalendarToSlack
 {
@@ -204,8 +205,8 @@ namespace CalendarToSlack
             Thread.Sleep(1500);
 
             var results = new List<SlackUserInfo>();
-
-            var data = Json.Decode(content);
+            
+            var data = (dynamic)JsonConvert.DeserializeObject(content);
             var members = data.members;
             foreach (var member in members)
             {

--- a/CalendarToSlack/packages.config
+++ b/CalendarToSlack/packages.config
@@ -4,4 +4,5 @@
   <package id="AWSSDK.SQS" version="3.1.0.4" targetFramework="net45" />
   <package id="log4net" version="2.0.5" targetFramework="net45" />
   <package id="Microsoft.Exchange.WebServices" version="2.2" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
I believe the number of users on our Slack account crept up just past the max length allowed by `Json.Decode()`. I modified a couple of places where we did JSON deserialization to use Newtonsoft.Json instead and this fixed the crash.