### PR TITLE
Update to use Slack custom status API

### DIFF
--- a/CalendarToSlack/Slack.cs
+++ b/CalendarToSlack/Slack.cs
@@ -196,6 +196,10 @@ namespace CalendarToSlack
             foreach (var member in members)
             {
                 // startup presence = member.presence
+                // 
+                // This assumes that the custom status of the user at startup is their desired default, 
+                // but if the app starts when the user has a meeting or OOO-related status set, that will be
+                // used as the default. TODO: add manual default status setting: https://github.com/robhruska/CalendarToSlack/issues/17
                 results.Add(new SlackUserInfo
                 {
                     UserId = member.id,

--- a/CalendarToSlack/Slack.cs
+++ b/CalendarToSlack/Slack.cs
@@ -178,19 +178,6 @@ namespace CalendarToSlack
             Thread.Sleep(1500);
         }
 
-        private static string GetLastNameWithAppendedMessage(RegisteredUser user, string message)
-        {
-            const int maxLastName = 35;
-            const string separator = " | ";
-
-            var newLastName = user.SlackUserInfo.ActualLastName;
-            if (!string.IsNullOrWhiteSpace(message))
-            {
-                newLastName = user.SlackUserInfo.ActualLastName + separator + message.Substring(0, Math.Min(message.Length, maxLastName - (user.SlackUserInfo.ActualLastName.Length + separator.Length)));
-            }
-            return newLastName;
-        }
-
         public List<SlackUserInfo> ListUsers(string authToken)
         {
             var result = _http.GetAsync(string.Format("https://slack.com/api/users.list?token={0}&presence=1", authToken)).Result;

--- a/CalendarToSlack/Slack.cs
+++ b/CalendarToSlack/Slack.cs
@@ -238,8 +238,6 @@ namespace CalendarToSlack
 
         public string DefaultStatusText { get; set; }
         public string DefaultStatusEmoji { get; set; }
-
-        public string ActualLastName { get { return LastName.Split('|')[0].Trim(); } }
     }
 
     enum Presence

--- a/CalendarToSlack/Slack.cs
+++ b/CalendarToSlack/Slack.cs
@@ -203,6 +203,8 @@ namespace CalendarToSlack
                     FirstName = member.profile.first_name,
                     LastName = member.profile.last_name,
                     Email = member.profile.email,
+                    DefaultStatusText = member.profile.status_text,
+                    DefaultStatusEmoji = member.profile.status_emoji,
                 });
             }
             return results;
@@ -229,6 +231,9 @@ namespace CalendarToSlack
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public string Email { get; set; }
+
+        public string DefaultStatusText { get; set; }
+        public string DefaultStatusEmoji { get; set; }
 
         public string ActualLastName { get { return LastName.Split('|')[0].Trim(); } }
     }

--- a/CalendarToSlack/Slack.cs
+++ b/CalendarToSlack/Slack.cs
@@ -133,7 +133,7 @@ namespace CalendarToSlack
             Thread.Sleep(1500);
         }
 
-        public void UpdateProfileWithStatus(RegisteredUser user, string message, string emoji)
+        public void UpdateProfileWithStatus(RegisteredUser user, CustomStatus status)
         {
             // Slack's support for status/presence (i.e. only auto/away) is limited, and one of
             // our conventions for broadcasting more precise status is to change our last name
@@ -156,9 +156,14 @@ namespace CalendarToSlack
                 return;
             }
 
-            var profile = $"{{\"status_text\":\"{message}\",\"status_emoji\":\"{emoji}\"}}";
+            if (status == null)
+            {
+                return;
+            }
 
-            Log.Info($"Changed profile status text to {message} and emoji to {emoji}");
+            var profile = $"{{\"status_text\":\"{status.StatusText}\",\"status_emoji\":\"{status.StatusEmoji}\"}}";
+
+            Log.Info($"Changed profile status text to {status.StatusText} and emoji to {status.StatusEmoji}");
             
             var content = new FormUrlEncodedContent(new Dictionary<string, string>
             {
@@ -207,8 +212,7 @@ namespace CalendarToSlack
                     FirstName = member.profile.first_name,
                     LastName = member.profile.last_name,
                     Email = member.profile.email,
-                    DefaultStatusText = member.profile.status_text,
-                    DefaultStatusEmoji = member.profile.status_emoji,
+                    DefaultCustomStatus = new CustomStatus { StatusText = member.profile.status_text, StatusEmoji = member.profile.status_emoji }
                 });
             }
             return results;
@@ -236,8 +240,7 @@ namespace CalendarToSlack
         public string LastName { get; set; }
         public string Email { get; set; }
 
-        public string DefaultStatusText { get; set; }
-        public string DefaultStatusEmoji { get; set; }
+        public CustomStatus DefaultCustomStatus { get; set; }
     }
 
     class CustomStatus

--- a/CalendarToSlack/Slack.cs
+++ b/CalendarToSlack/Slack.cs
@@ -240,6 +240,17 @@ namespace CalendarToSlack
         public string DefaultStatusEmoji { get; set; }
     }
 
+    class CustomStatus
+    {
+        public string StatusText { get; set; }
+        public string StatusEmoji { get; set; }
+
+        public override string ToString()
+        {
+            return !string.IsNullOrWhiteSpace(StatusEmoji) ? $"{StatusText};{StatusEmoji}" : StatusText;
+        }
+    }
+
     enum Presence
     {
         Away,

--- a/CalendarToSlack/Slack.cs
+++ b/CalendarToSlack/Slack.cs
@@ -133,7 +133,7 @@ namespace CalendarToSlack
             Thread.Sleep(1500);
         }
 
-        public void UpdateProfileWithStatusMessage(RegisteredUser user, string message)
+        public void UpdateProfileWithStatus(RegisteredUser user, string message, string emoji)
         {
             // Slack's support for status/presence (i.e. only auto/away) is limited, and one of
             // our conventions for broadcasting more precise status is to change our last name
@@ -156,11 +156,9 @@ namespace CalendarToSlack
                 return;
             }
 
-            var newLastName = GetLastNameWithAppendedMessage(user, message);
+            var profile = $"{{\"status_text\":\"{message}\",\"status_emoji\":\"{emoji}\"}}";
 
-            var profile = string.Format("{{\"first_name\":\"{0}\",\"last_name\":\"{1}\"}}", user.SlackUserInfo.FirstName, newLastName);
-
-            Log.InfoFormat("Changed profile last name to \"{0}\"", newLastName);
+            Log.Info($"Changed profile status text to {message} and emoji to {emoji}");
             
             var content = new FormUrlEncodedContent(new Dictionary<string, string>
             {

--- a/CalendarToSlack/Updater.cs
+++ b/CalendarToSlack/Updater.cs
@@ -286,14 +286,22 @@ namespace CalendarToSlack
             return true;
         }
 
-        private static StatusMessageFilter MatchFilter(string subject, List<StatusMessageFilter> filters)
+        private static CustomStatus MatchFilter(string subject, Dictionary<string, CustomStatus> filters)
         {
             if (string.IsNullOrWhiteSpace(subject))
             {
                 return null;
             }
 
-            return filters.Find(f => subject.IndexOf(f.Key, StringComparison.OrdinalIgnoreCase) >= 0);
+            foreach (var filter in filters)
+            {
+                if (subject.IndexOf(filter.Key, StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    return filter.Value;
+                }
+            }
+
+            return null;
         }
 
         private static LegacyFreeBusyStatus GetBusiestStatus(List<CalendarEvent> events)

--- a/CalendarToSlack/Updater.cs
+++ b/CalendarToSlack/Updater.cs
@@ -221,7 +221,7 @@ namespace CalendarToSlack
         {
             if (ev == null)
             {
-                return user.SlackUserInfo.DefaultCustomStatus;
+                return null;
             }
 
             // Will be null if no matches.

--- a/CalendarToSlack/Updater.cs
+++ b/CalendarToSlack/Updater.cs
@@ -190,8 +190,8 @@ namespace CalendarToSlack
             // Otherwise, we're transitioning into an event that's coming up (or just got added).
 
             var presenceToSet = GetPresenceForAvailability(busiestEvent.FreeBusyStatus);
-            var withMessage = (string.IsNullOrWhiteSpace(statusMessage) ? "(with no message)" :
-                $"(with message \"| {statusMessage}\")");
+            var withMessage = (string.IsNullOrWhiteSpace(statusMessage) && string.IsNullOrWhiteSpace(statusEmoji)) ? "(with no status)" :
+                $"with status text \"{statusMessage}\" and emoji \"{statusEmoji}\"";
             var slackbotMessage = $"Changed your status to {presenceToSet} {withMessage} for \"{busiestEvent.Subject}\"";
             Log.InfoFormat("{0} is now {1} {2} for \"{3}\" (event status \"{4}\") ", user.Email, presenceToSet, withMessage, busiestEvent.Subject, busiestEvent.FreeBusyStatus);
             MakeSlackApiCalls(user, presenceToSet, statusMessage, statusEmoji, slackbotMessage);

--- a/CalendarToSlack/Updater.cs
+++ b/CalendarToSlack/Updater.cs
@@ -216,7 +216,7 @@ namespace CalendarToSlack
             LegacyFreeBusyStatus.Free,
         };
 
-        // Returns an empty string if the user should have no status message.
+        // Returns null if the user's status should not be updated.
         private static CustomStatus GetCustomStatusForCalendarEvent(CalendarEvent ev, RegisteredUser user)
         {
             if (ev == null)

--- a/CalendarToSlack/Updater.cs
+++ b/CalendarToSlack/Updater.cs
@@ -183,7 +183,7 @@ namespace CalendarToSlack
                 {
                     message = $"{message} after your whitelist was updated";
                 }
-                MakeSlackApiCalls(user, Presence.Auto, "", "", message);
+                MakeSlackApiCalls(user, Presence.Auto, user.SlackUserInfo.DefaultStatusText, user.SlackUserInfo.DefaultStatusEmoji, message);
                 return;
             }
 

--- a/CalendarToSlack/Updater.cs
+++ b/CalendarToSlack/Updater.cs
@@ -222,7 +222,7 @@ namespace CalendarToSlack
         {
             if (ev == null)
             {
-                return string.Empty;
+                return "";
             }
 
             // Will be null if no matches.

--- a/CalendarToSlack/UserDatabase.cs
+++ b/CalendarToSlack/UserDatabase.cs
@@ -403,7 +403,7 @@ namespace CalendarToSlack
 
         public bool HasSetCurrentEvent { get { return _hasSetCurrentEvent; } }
 
-        public string CurrentCustomMessage { get; set; }
+        public CustomStatus CurrentCustomStatus { get; set; }
 
         public SlackUserInfo SlackUserInfo { get; set; }
 


### PR DESCRIPTION
This updates the app to leverage Slack's custom status API (still at `users.profile.set`). It's a pretty straightforward change to actually set the custom status -- instead of sending `first_name` and `last_name` in the URL-encoded `profile` field, we now send `status_text` and `status_emoji` fields. The fields will be empty strings if the user's event is now over or if there is no emoji mapping for the current event status.

I also added support for custom entries for status emoji in your whitelist. Now, a whitelist entry can look like: `OOO`, `Out of Office>OOO`, `OOO;:house:` or `Out of Office>OOO;:house:`. The `>` delimits filter keys and status text, while `;` delimits status text from the status emoji.

Main thing I'm looking for in CR is just to know if there are any other places in the app we make assumptions based on the message being in the `last_name` field. Testing locally _seemed_ to work 😄 