### PR TITLE
Fully remove System.Web.Helpers and target 4.6.1

### DIFF
--- a/CalendarToSlack/App.config
+++ b/CalendarToSlack/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
     </startup>
 </configuration>

--- a/CalendarToSlack/CalendarToSlack.csproj
+++ b/CalendarToSlack/CalendarToSlack.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CalendarToSlack</RootNamespace>
     <AssemblyName>CalendarToSlack</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />
@@ -61,9 +61,6 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Web.Helpers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/CalendarToSlack/Http/HttpServer.cs
+++ b/CalendarToSlack/Http/HttpServer.cs
@@ -6,7 +6,6 @@ using System.Net.Http;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using System.Web.Helpers;
 using log4net;
 using Newtonsoft.Json;
 

--- a/CalendarToSlack/Slack.cs
+++ b/CalendarToSlack/Slack.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
-using System.Web.Helpers;
 using log4net;
 using Newtonsoft.Json;
 
@@ -73,7 +72,7 @@ namespace CalendarToSlack
             // TODO temporary hack to avoid Slack's rate limit. a longer-term solution is being investigated.
             Thread.Sleep(1500);
 
-            var data = Json.Decode(content);
+            var data = (dynamic)JsonConvert.DeserializeObject(content);
             var info = GetUserInfo(authToken, data.user_id);
 
             return info;
@@ -90,7 +89,7 @@ namespace CalendarToSlack
             // TODO temporary hack to avoid Slack's rate limit. a longer-term solution is being investigated.
             Thread.Sleep(1500);
 
-            var data = Json.Decode(content);
+            var data = (dynamic)JsonConvert.DeserializeObject(content);
             return new SlackUserInfo
             {
                 FirstName = data.user.profile.first_name,


### PR DESCRIPTION
I was having problems with the `System.Web.Helpers` reference locally. It's a bit nonstandard, so I removed it and switched usage over to Newtonsoft.Json now that it's already a package reference.

Also updated the framework target from 4.5 to 4.5.1.