### PR TITLE
Explicitly do not unfurl the media in event Location URLs

### DIFF
--- a/CalendarToSlack/Slack.cs
+++ b/CalendarToSlack/Slack.cs
@@ -100,7 +100,7 @@ namespace CalendarToSlack
             };
         }
 
-        public void PostSlackbotMessage(string authToken, string username, string message)
+        public void PostSlackbotMessage(string authToken, string username, string message, bool unfurlLinks = true)
         {
             Log.InfoFormat("Posting message to @{0}'s slackbot: {1}", username, message);
 
@@ -110,6 +110,7 @@ namespace CalendarToSlack
                 { "channel", "@" + username },
                 { "as_user", "false" },
                 { "text", message },
+                { "unfurl_links", unfurlLinks ? "true" : "false" },
                 { "username", "Calendar To Slack" },
             };
 

--- a/CalendarToSlack/Updater.cs
+++ b/CalendarToSlack/Updater.cs
@@ -212,7 +212,7 @@ namespace CalendarToSlack
             }
             if (!string.IsNullOrWhiteSpace(slackbotLocationLinkMessage))
             {
-                _slack.PostSlackbotMessage(user.SlackApplicationAuthToken, user.SlackUserInfo.Username, slackbotLocationLinkMessage);
+                _slack.PostSlackbotMessage(user.SlackApplicationAuthToken, user.SlackUserInfo.Username, slackbotLocationLinkMessage, false);
             }
             _slack.UpdateProfileWithStatus(user, customStatus);
             _slack.SetPresence(user.SlackApplicationAuthToken, presence);


### PR DESCRIPTION
When the slackbot DMs you the URL for an event (if the event Location is a URL), we now tell Slack to explicitly NOT 'unfurl' it.

More info on what this means: https://api.slack.com/docs/message-link-unfurling

In other words, don't do this:

![image](https://user-images.githubusercontent.com/1224017/32618119-6b34fc5a-c53c-11e7-9cb0-e48fcf529c21.png)
