### PR TITLE
Remove full access token usage

### DIFF
--- a/CalendarToSlack/Http/HttpServer.cs
+++ b/CalendarToSlack/Http/HttpServer.cs
@@ -129,14 +129,14 @@ namespace CalendarToSlack.Http
                         }
 
                         var token = (string)json.access_token;
-                        var user = _slack.GetUserInfo(token);
+                        var slackUser = _slack.GetUserInfo(token);
 
-                        if (_database.AddUser(user, token))
+                        if (_database.AddUser(slackUser, token))
                         {
-                            _slack.PostSlackbotMessage(token, user.Username, "Hey there! I'll be modifying your Slack free/away status when events come up on your calendar. How neat is that?\nSee https://github.com/robhruska/CalendarToSlack/wiki for all the cool things I can do.");
+                            _slack.PostSlackbotMessage(token, slackUser, "Hey there! I'll be modifying your Slack free/away status when events come up on your calendar. How neat is that?\nSee https://github.com/robhruska/CalendarToSlack/wiki for all the cool things I can do.");
                         }
 
-                        SendHtml(context.Response, 200, "Added " + user.Email + ". Check out <a href=\"https://github.com/robhruska/CalendarToSlack/wiki\">the wiki</a>.");
+                        SendHtml(context.Response, 200, "Added " + slackUser.Email + ". Check out <a href=\"https://github.com/robhruska/CalendarToSlack/wiki\">the wiki</a>.");
                     }
                     else
                     {

--- a/CalendarToSlack/Http/Resources/index.html
+++ b/CalendarToSlack/Http/Resources/index.html
@@ -42,7 +42,7 @@
         <h1>Calendar to Slack</h1>
         <p>When an event is happening on your Outlook calendar, CalendarToSlack updates your Slack presence to "Away" and optionally appends a custom message (e.g. <span class="pre">| Away</span>) to your last name.</p>
         
-        <a id="add-to-slack" class="hvr-grow-rotate" href="https://slack.com/oauth/authorize?client_id={{SlackClientId}}&scope=commands+users%3Aread+users%3Awrite+chat%3Awrite%3Abot+chat%3Awrite%3Auser"><img alt="Add to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x"></a>
+        <a id="add-to-slack" class="hvr-grow-rotate" href="https://slack.com/oauth/authorize?client_id={{SlackClientId}}&scope=commands+users%3Aread+users%3Awrite+users.profile%3Awrite+chat%3Awrite%3Abot+chat%3Awrite%3Auser"><img alt="Add to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x"></a>
 
         <p>
             <img src="https://raw.githubusercontent.com/robhruska/CalendarToSlack/master/docs/calendar-event.png" />

--- a/CalendarToSlack/Http/Resources/index.html
+++ b/CalendarToSlack/Http/Resources/index.html
@@ -50,27 +50,5 @@
         </p>
         
         <p>For a comprehensive list of features and instructions, see the <a href="https://github.com/robhruska/CalendarToSlack/wiki">CalendarToSlack Wiki</a>.</p>
-        <!--
-        <h2>Features</h2>
-        
-        <i>Status messages in last name.</i>
-        <p>If the full-access token is provided, status messages are appended to your last name, so your full name displays as something like <span class="pre">Rob Hruska | Away</span>.</p>
-        <p><b>Prerequisite:</b> you'll have to give your personal, full-access Slack auth token to the server administrator. Contact them and discuss the security implications of that.</p>
-
-        <i>Whitelist support for status messages.</i>
-        <p>Example: <span class="pre">Lunch|1:1|Standup|Meeting|Planning&gt;Meeting</span></p>
-        <p>If any of these tokens are found in the calendar event subject, the token will be used as the status message instead of the default "Away".</p>
-        <p>A <span class="pre">&gt;</span> maps matched values on the left hand side to the status message on the right hand side.</p>
-        
-        <i>Conditional status based on OOO/Busy/Tentative/etc.</i>
-        
-        <p><i>OOO</i> and <i>Busy</i> events will set the status message and mark you as "Away". <i>Tentative</i> and <i>Working Elsewhere</i> events will set the status message, but keep your Slack status "Auto" (essentially "Available").</p>
-        
-        <h2>Tips &amp; Tricks</h2>
-        
-        <ul>
-            <li>In a different office for the week? Add an all-week <i>Working Elsewhere</i> event to your calendar named "London" and add "London" to your whitelist.</li>
-            <li>Want to stay available during lunch but let people know you're only partially around? Create a recurring 1-hour event named "Lunch" that's <i>Tentative</i>.</li>
-        </ul>-->
     </body>
 </html>

--- a/CalendarToSlack/Slack.cs
+++ b/CalendarToSlack/Slack.cs
@@ -53,9 +53,8 @@ namespace CalendarToSlack
             {
                 Log.ErrorFormat("Unsuccessful response status for users.setPresence: {0}", result.StatusCode);
             }
-
-            // TODO temporary hack to avoid Slack's rate limit. a longer-term solution is being investigated.
-            Thread.Sleep(1500);
+            
+            Throttle();
         }
 
 
@@ -69,8 +68,7 @@ namespace CalendarToSlack
             
             var content = result.Content.ReadAsStringAsync().Result;
 
-            // TODO temporary hack to avoid Slack's rate limit. a longer-term solution is being investigated.
-            Thread.Sleep(1500);
+            Throttle();
 
             var data = (dynamic)JsonConvert.DeserializeObject(content);
             var info = GetUserInfo(authToken, (string)data.user_id);
@@ -86,8 +84,7 @@ namespace CalendarToSlack
             
             var content = result.Content.ReadAsStringAsync().Result;
 
-            // TODO temporary hack to avoid Slack's rate limit. a longer-term solution is being investigated.
-            Thread.Sleep(1500);
+            Throttle();
 
             var data = (dynamic)JsonConvert.DeserializeObject(content);
             return new SlackUserInfo
@@ -129,33 +126,11 @@ namespace CalendarToSlack
                 Log.ErrorFormat("Unsuccessful response status for chat.postMessage: {0}", result.StatusCode);
             }
 
-            // TODO temporary hack to avoid Slack's rate limit. a longer-term solution is being investigated.
-            Thread.Sleep(1500);
+            Throttle();
         }
 
-        public void UpdateProfileWithStatus(RegisteredUser user, CustomStatus status)
-        {
-            // Slack's support for status/presence (i.e. only auto/away) is limited, and one of
-            // our conventions for broadcasting more precise status is to change our last name
-            // to something like "Rob Hruska | Busy" or "Rob Hruska | OOO til Mon".
-
-            // The users.profile.set API endpoint (which isn't public, but is used by the webapp
-            // version of Slack) requires the `post` scope, but applications can't request/authorize
-            // that scope because it's deprecated.
-            // 
-            // The "full access" token (from the Web API test page) does support post, but I don't
-            // want to manage those within the app here. I've temporarily allowed it for myself,
-            // but it'll be removed in the future.
-            //
-            // The current plan is to wait for Slack to either 1) expose a formal users.profile.set
-            // API, or 2) introduce custom away status messages.
-
-            if (string.IsNullOrWhiteSpace(user.HackyPersonalFullAccessSlackToken))
-            {
-                // Can't update without the full token.
-                return;
-            }
-
+        public void UpdateProfileWithStatus(string authToken, RegisteredUser user, CustomStatus status)
+        {            
             if (status == null)
             {
                 return;
@@ -167,8 +142,8 @@ namespace CalendarToSlack
             
             var content = new FormUrlEncodedContent(new Dictionary<string, string>
             {
+                { "token", authToken },
                 { "profile", profile },
-                { "token", user.HackyPersonalFullAccessSlackToken } // TODO switch to auth token. see comments above in this method
             });
             
             var result = _http.PostAsync("https://slack.com/api/users.profile.set", content).Result;
@@ -179,8 +154,7 @@ namespace CalendarToSlack
                 Log.ErrorFormat("Unsuccessful response status for users.profile.set: {0}", result.StatusCode);
             }
 
-            // TODO temporary hack to avoid Slack's rate limit. a longer-term solution is being investigated.
-            Thread.Sleep(1500);
+            Throttle();
         }
 
         public List<SlackUserInfo> ListUsers(string authToken)
@@ -191,8 +165,7 @@ namespace CalendarToSlack
 
             var content = result.Content.ReadAsStringAsync().Result;
 
-            // TODO temporary hack to avoid Slack's rate limit. a longer-term solution is being investigated.
-            Thread.Sleep(1500);
+            Throttle();
 
             var results = new List<SlackUserInfo>();
             
@@ -228,6 +201,14 @@ namespace CalendarToSlack
             {
                 Log.ErrorFormat("Error logging Slack API result: " + e.Message);
             }
+        }
+
+        private void Throttle()
+        {
+            // To avoid Slack's rate limit. This is a carryover from when this app used a different API; it may
+            // not be needed anymore. It used to be 1500. I dropped it to 100 just to keep a bit of a throttle
+            // in place.
+            Thread.Sleep(100);
         }
     }
 

--- a/CalendarToSlack/Slack.cs
+++ b/CalendarToSlack/Slack.cs
@@ -97,14 +97,14 @@ namespace CalendarToSlack
             };
         }
 
-        public void PostSlackbotMessage(string authToken, string username, string message, bool unfurlLinks = true)
+        public void PostSlackbotMessage(string authToken, SlackUserInfo user, string message, bool unfurlLinks = true)
         {
-            Log.InfoFormat("Posting message to @{0}'s slackbot: {1}", username, message);
+            Log.InfoFormat("Posting message to @{0}'s slackbot: {1}", user.Username, message);
 
             var options = new Dictionary<string, string>
             {
                 { "token", authToken },
-                { "channel", "@" + username },
+                { "channel", "@" + user.Username },
                 { "as_user", "false" },
                 { "text", message },
                 { "unfurl_links", unfurlLinks ? "true" : "false" },
@@ -119,7 +119,7 @@ namespace CalendarToSlack
             var content = new FormUrlEncodedContent(options);
 
             var result = _http.PostAsync("https://slack.com/api/chat.postMessage", content).Result;
-            LogSlackApiResult("chat.postMessage " + username, result);
+            LogSlackApiResult("chat.postMessage " + user.Username, result);
 
             if (!result.IsSuccessStatusCode)
             {
@@ -129,7 +129,7 @@ namespace CalendarToSlack
             Throttle();
         }
 
-        public void UpdateProfileWithStatus(string authToken, RegisteredUser user, CustomStatus status)
+        public void UpdateProfileWithStatus(string authToken, SlackUserInfo user, CustomStatus status)
         {            
             if (status == null)
             {
@@ -147,7 +147,7 @@ namespace CalendarToSlack
             });
             
             var result = _http.PostAsync("https://slack.com/api/users.profile.set", content).Result;
-            LogSlackApiResult("users.profile.set " + user.SlackUserInfo.Username, result);
+            LogSlackApiResult("users.profile.set " + user.Username, result);
 
             if (!result.IsSuccessStatusCode)
             {

--- a/CalendarToSlack/Updater.cs
+++ b/CalendarToSlack/Updater.cs
@@ -208,13 +208,13 @@ namespace CalendarToSlack
         {
             if (user.SendSlackbotMessageOnChange)
             {
-                _slack.PostSlackbotMessage(user.SlackApplicationAuthToken, user.SlackUserInfo.Username, slackbotDebugMessage);
+                _slack.PostSlackbotMessage(user.SlackApplicationAuthToken, user.SlackUserInfo, slackbotDebugMessage);
             }
             if (!string.IsNullOrWhiteSpace(slackbotLocationLinkMessage))
             {
-                _slack.PostSlackbotMessage(user.SlackApplicationAuthToken, user.SlackUserInfo.Username, slackbotLocationLinkMessage, false);
+                _slack.PostSlackbotMessage(user.SlackApplicationAuthToken, user.SlackUserInfo, slackbotLocationLinkMessage, false);
             }
-            _slack.UpdateProfileWithStatus(user.SlackApplicationAuthToken, user, customStatus);
+            _slack.UpdateProfileWithStatus(user.SlackApplicationAuthToken, user.SlackUserInfo, customStatus);
             _slack.SetPresence(user.SlackApplicationAuthToken, presence);
         }
 

--- a/CalendarToSlack/Updater.cs
+++ b/CalendarToSlack/Updater.cs
@@ -214,7 +214,7 @@ namespace CalendarToSlack
             {
                 _slack.PostSlackbotMessage(user.SlackApplicationAuthToken, user.SlackUserInfo.Username, slackbotLocationLinkMessage, false);
             }
-            _slack.UpdateProfileWithStatus(user, customStatus);
+            _slack.UpdateProfileWithStatus(user.SlackApplicationAuthToken, user, customStatus);
             _slack.SetPresence(user.SlackApplicationAuthToken, presence);
         }
 

--- a/CalendarToSlack/UserDatabase.cs
+++ b/CalendarToSlack/UserDatabase.cs
@@ -70,7 +70,6 @@ namespace CalendarToSlack
                 {
                     Email = fields[0],
                     SlackApplicationAuthToken = fields[1],
-                    HackyPersonalFullAccessSlackToken = fields[2],
                     StatusMessageFilters = filters,
                     Options = options,
                 };
@@ -184,7 +183,7 @@ namespace CalendarToSlack
             {
                 var options = string.Join("|", user.Options.Select(option => option.ToString()));
                 var filters = SerializeMessageFilters(user.StatusMessageFilters);
-                var line = string.Format("{0},{1},{2},{3},{4}", user.Email, user.SlackApplicationAuthToken ?? "", user.HackyPersonalFullAccessSlackToken ?? "", options, filters);
+                var line = string.Format("{0},{1},{2},{3},{4}", user.Email, user.SlackApplicationAuthToken ?? "", "", options, filters);
                 lines.Add(line);
             }
             
@@ -382,7 +381,6 @@ namespace CalendarToSlack
         public string Email { get; set; }
 
         public string SlackApplicationAuthToken { get; set; }
-        public string HackyPersonalFullAccessSlackToken { get; set; } // Will be removed.
         public Dictionary<string, CustomStatus> StatusMessageFilters { get; set; }
         public HashSet<Option> Options { get; set; } 
 

--- a/CalendarToSlack/UserDatabase.cs
+++ b/CalendarToSlack/UserDatabase.cs
@@ -313,7 +313,7 @@ namespace CalendarToSlack
                 var addedTokenString = GetTokenListForSlackbot(dictionary);
                 var whitelistTokenString = GetTokenListForSlackbot(user.StatusMessageFilters);
                 var message = string.Format("Added token(s):\n{0}\nWhitelist:\n{1}", addedTokenString, whitelistTokenString);
-                _slack.PostSlackbotMessage(user.SlackApplicationAuthToken, user.SlackUserInfo.Username, message);
+                _slack.PostSlackbotMessage(user.SlackApplicationAuthToken, user.SlackUserInfo, message);
             }
         }
 
@@ -348,7 +348,7 @@ namespace CalendarToSlack
                 var removedTokenString = GetTokenListForSlackbot(remove);
                 var whitelistTokenString = GetTokenListForSlackbot(user.StatusMessageFilters);
                 var message = $"Removed token(s):\n{removedTokenString}\nWhitelist:\n{whitelistTokenString}";
-                _slack.PostSlackbotMessage(user.SlackApplicationAuthToken, user.SlackUserInfo.Username, message);
+                _slack.PostSlackbotMessage(user.SlackApplicationAuthToken, user.SlackUserInfo, message);
             }
         }
 
@@ -362,7 +362,7 @@ namespace CalendarToSlack
             var user = FindUserById(userId);
             var tokenString = GetTokenListForSlackbot(user.StatusMessageFilters);
             var message = string.Format("Whitelist:\n{0}", tokenString);
-            _slack.PostSlackbotMessage(user.SlackApplicationAuthToken, user.SlackUserInfo.Username, message);
+            _slack.PostSlackbotMessage(user.SlackApplicationAuthToken, user.SlackUserInfo, message);
         }
 
         private RegisteredUser FindUserById(string userId)


### PR DESCRIPTION
Slack originally had no public API for setting user status, so we were concatenating the status to their username, which required an undocumented, organization-level API.

Slack now has the `users.profile:set` scope that can set status/emoji, and we're using that instead.

This removes the old stuff.

See #16 and the block comments removed from the code for more detail.