### PR TITLE
Revamp /c2s-whitelist command

### DIFF
--- a/CalendarToSlack/SlackCommandConsumer.cs
+++ b/CalendarToSlack/SlackCommandConsumer.cs
@@ -178,6 +178,7 @@ namespace CalendarToSlack
                     .Select(m => m.Value.Replace("\"", ""))
                     .ToList();
                 
+                // /c2s-whitelist
                 if (options.Count == 0)
                 {
                     _userdb.EchoWhitelistToSlackbot(userId);
@@ -188,6 +189,13 @@ namespace CalendarToSlack
                 var args = (options.Count > 1 ? options.Skip(1).ToList() : new List<string>());
                 
                 Log.DebugFormat($"subcommand = {subcommand}, args = {string.Join("|", args)}");
+
+                // /c2s-whitelist help
+                if (subcommand.Equals("help", StringComparison.OrdinalIgnoreCase))
+                {
+                    _userdb.EchoWhitelistSyntaxToSlackbot(userId);
+                    return;
+                }
 
                 // /c2s-whitelist set "Working From Home"
                 // /c2s-whitelist set "Working From Home" :home:
@@ -227,7 +235,7 @@ namespace CalendarToSlack
 
                 // /c2s-whitelist remove "Working From Home"
                 // /c2s-whitelist remove NSS
-                else if (subcommand.Equals("remove", StringComparison.OrdinalIgnoreCase))
+                if (subcommand.Equals("remove", StringComparison.OrdinalIgnoreCase))
                 {
                     if (args.Count == 0) return;
 
@@ -242,14 +250,14 @@ namespace CalendarToSlack
                 // /c2s-whitelist set-default Marvel :marvel:
                 // /c2s-whitelist set-default :marvel:
                 // /c2s-whitelist set-default "Project Marvel" :marvel:
-                else if (subcommand.Equals("set-default", StringComparison.OrdinalIgnoreCase))
+                if (subcommand.Equals("set-default", StringComparison.OrdinalIgnoreCase))
                 {
                     // TODO implement
                     return;
                 }
 
                 // /c2s-whitelist remove-default
-                else if (subcommand.Equals("remove-default", StringComparison.OrdinalIgnoreCase))
+                if (subcommand.Equals("remove-default", StringComparison.OrdinalIgnoreCase))
                 {
                     // TODO implement
                     return;

--- a/CalendarToSlack/SlackCommandConsumer.cs
+++ b/CalendarToSlack/SlackCommandConsumer.cs
@@ -1,13 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Threading;
-using System.Threading.Tasks;
-using Amazon;
+﻿using Amazon;
 using Amazon.SQS;
 using Amazon.SQS.Model;
 using log4net;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace CalendarToSlack
 {
@@ -165,46 +166,111 @@ namespace CalendarToSlack
 
                 return;
             }
+            
+            // TODO case sensitivity
+            // TODO manage default status
 
             if (command == "whitelist")
             {
                 var text = WebUtility.UrlDecode(fields["text"]);
-                var options = text.Split();
-                if (options.Length == 0 || (options.Length == 1 && (string.IsNullOrWhiteSpace(options[0]) || string.Equals(options[0], "show", StringComparison.OrdinalIgnoreCase))))
+                var options = Regex.Matches(text.Trim(), @"[\""].+?[\""]|[^ ]+")
+                    .Cast<Match>()
+                    .Select(m => m.Value.Replace("\"", ""))
+                    .ToList();
+                
+                if (options.Count == 0)
                 {
                     _userdb.EchoWhitelistToSlackbot(userId);
                     return;
                 }
 
-                if (options.Length >= 2)
+                var subcommand = options[0];
+                var args = (options.Count > 1 ? options.Skip(1).ToList() : new List<string>());
+                
+                Log.DebugFormat($"subcommand = {subcommand}, args = {string.Join("|", args)}");
+
+                // /c2s-whitelist set "Working From Home"
+                // /c2s-whitelist set "Working From Home" :home:
+                // /c2s-whitelist set "Working From Home" "WFH"
+                // /c2s-whitelist set "Working From Home" "WFH" :home:
+                // /c2s-whitelist set Plan
+                // /c2s-whitelist set Plan :calendar:
+                // /c2s-whitelist set Plan Meeting
+                // /c2s-whitelist set Plan Meeting :calendar:
+                if (subcommand.Equals("set", StringComparison.OrdinalIgnoreCase))
                 {
-                    if (string.Equals(options[0], "add", StringComparison.OrdinalIgnoreCase))
+                    if (args.Count == 0) return;
+
+                    if (args.Any(ContainsIllegalCharacters)) return;
+
+                    var token = args[0];
+                    
+                    if (args.Count == 2)
                     {
-                        var combined = new HashSet<string>();
-                        for (var i = 1; i < options.Length; i++)
+                        if (IsEmoji(args[1]))
                         {
-                            combined.Add(options[i]);
+                            token += $";{args[1]}";
                         }
-                        _userdb.AddToWhitelist(userId, string.Join("|", combined));
-                        return;
+                        else
+                        {
+                            token += $">{args[1]}";
+                        }
+                    }
+                    else if (args.Count >= 3)
+                    {
+                        token += $">{args[1]};{args[2]}";
                     }
 
-                    if (string.Equals(options[0], "remove", StringComparison.OrdinalIgnoreCase))
-                    {
-                        var combined = new HashSet<string>();
-                        for (var i = 1; i < options.Length; i++)
-                        {
-                            combined.Add(options[i]);
-                        }
-                        _userdb.RemoveFromWhitelist(userId, string.Join("|", combined));
-                        return;
-                    }
+                    _userdb.AddToWhitelist(userId, token);
+                    return;
                 }
-                
-                return;
+
+                // /c2s-whitelist remove "Working From Home"
+                // /c2s-whitelist remove NSS
+                else if (subcommand.Equals("remove", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (args.Count == 0) return;
+
+                    if (args.Any(ContainsIllegalCharacters)) return;
+
+                    var token = args[0];
+                    _userdb.RemoveFromWhitelist(userId, token);
+                    return;
+                }
+
+                // /c2s-whitelist set-default Marvel
+                // /c2s-whitelist set-default Marvel :marvel:
+                // /c2s-whitelist set-default :marvel:
+                // /c2s-whitelist set-default "Project Marvel" :marvel:
+                else if (subcommand.Equals("set-default", StringComparison.OrdinalIgnoreCase))
+                {
+                    // TODO implement
+                    return;
+                }
+
+                // /c2s-whitelist remove-default
+                else if (subcommand.Equals("remove-default", StringComparison.OrdinalIgnoreCase))
+                {
+                    // TODO implement
+                    return;
+                }
             }
 
             Log.ErrorFormat("Unrecognized slash command {0} from user {1}", command, userId);
+        }
+
+        private static bool IsEmoji(string arg)
+        {
+            if (string.IsNullOrWhiteSpace(arg)) return false;
+            
+            return arg.StartsWith(":") && arg.EndsWith(":");
+        }
+
+        private static bool ContainsIllegalCharacters(string arg)
+        {
+            if (string.IsNullOrWhiteSpace(arg)) return false;
+
+            return arg.Contains(";") || arg.Contains(">") || arg.Contains("|");
         }
     }
 }

--- a/CalendarToSlack/UserDatabase.cs
+++ b/CalendarToSlack/UserDatabase.cs
@@ -286,14 +286,14 @@ namespace CalendarToSlack
         {
             if (string.IsNullOrWhiteSpace(token))
             {
-                Log.WarnFormat("No token provided by {0} to add to whitelist", userId);
+                Log.Warn($"No token provided by {userId} to add to whitelist");
                 return;
             }
 
             var user = FindUserById(userId);
             if (user == null)
             {
-                Log.WarnFormat("Cannot find user id {0} to add to their whitelist", userId);
+                Log.Warn($"Cannot find user id {userId} to add to their whitelist");
                 return;
             }
 
@@ -309,11 +309,9 @@ namespace CalendarToSlack
                 }
 
                 WriteFile();
-
-                var addedTokenString = GetTokenListForSlackbot(dictionary);
-                var whitelistTokenString = GetTokenListForSlackbot(user.StatusMessageFilters);
-                var message = string.Format("Added token(s):\n{0}\nWhitelist:\n{1}", addedTokenString, whitelistTokenString);
-                _slack.PostSlackbotMessage(user.SlackApplicationAuthToken, user.SlackUserInfo, message);
+                
+                var message = $"Added `{token}`";
+                EchoWhitelistToSlackbot(userId, false, message);
             }
         }
 
@@ -344,27 +342,40 @@ namespace CalendarToSlack
                 }
                 
                 WriteFile();
-
-                var removedTokenString = GetTokenListForSlackbot(remove);
-                var whitelistTokenString = GetTokenListForSlackbot(user.StatusMessageFilters);
-                var message = $"Removed token(s):\n{removedTokenString}\nWhitelist:\n{whitelistTokenString}";
-                _slack.PostSlackbotMessage(user.SlackApplicationAuthToken, user.SlackUserInfo, message);
+                
+                var message = $"Removed `{token}`";
+                EchoWhitelistToSlackbot(userId, false, message);
             }
         }
 
-        private static string GetTokenListForSlackbot(Dictionary<string, CustomStatus> filters)
-        {
-            return string.Join(" ", filters.Select(f => f.Key == f.Value.StatusText ? f.Value.ToString() : $"{f.Key}>{f.Value}"));
-        }
-
-        public void EchoWhitelistToSlackbot(string userId)
+        public void EchoWhitelistToSlackbot(string userId, bool withCommentary = true, string flashMessage = null)
         {
             var user = FindUserById(userId);
 
-            // TODO implement
-            var text = "*Your default status is: :whiskeyrob: `Not yet implemented!`*\n";
-            text += "_This is used when you don't have an active calendar event. To change your default status, use_ `/c2s-default-status`\n\n";
-            text += "*Your whitelisted &amp; mapped statuses:*\n_If a calendar event name matches these, they'll be used as your Slack status. Matching events can be transformed to different Slack statuses (shown with `>`). If unmatched, a generic Slack status (e.g. \"Away\" or \"OOO\") will be used. Use `/c2s-whitelist` to manage this list._\n\n";
+            var text = "";
+            text += "--------------------\n";
+
+            if (!string.IsNullOrWhiteSpace(flashMessage))
+            {
+                text += $":white_check_mark: *Ok!* {flashMessage}\n";
+                text += "--------------------\n\n";
+            }
+            
+            // TODO implement defaults
+            text += "*Your default status is: :whiskeyrob: `Not yet implemented!`*\n";
+            if (withCommentary)
+            {
+                text += "_This is used when you don't have an active calendar event. To change your default status, use_ `/c2s-default-status`\n";
+            }
+            text += "\n";
+
+            text += "*Your whitelisted &amp; mapped statuses:*\n";
+            if (withCommentary)
+            {
+                text += "_If a calendar event name matches these, they'll be used as your Slack status. Matching events can be transformed to different Slack statuses (shown with `>`). If unmatched, a generic Slack status (e.g. \"Away\" or \"OOO\") will be used. Use `/c2s-whitelist` to manage this list._\n";
+            }
+            text += "\n";
+            
             foreach (var filter in user.StatusMessageFilters.OrderBy(filter => filter.Key))
             {
                 var emoji = (string.IsNullOrWhiteSpace(filter.Value.StatusEmoji) ? ":transparent:" : filter.Value.StatusEmoji);

--- a/CalendarToSlack/UserDatabase.cs
+++ b/CalendarToSlack/UserDatabase.cs
@@ -348,6 +348,24 @@ namespace CalendarToSlack
             }
         }
 
+        public void EchoWhitelistSyntaxToSlackbot(string userId)
+        {
+            var user = FindUserById(userId);
+
+            var text = "*Usage:*\n";
+            text += "`/c2s-whitelist` - Show current whitelist.\n";
+            text += "`/c2s-whitelist help` - Show this message.\n";
+            text += "`/c2s-whitelist set \"Working From Home\"` - Show status as `Working From Home` when event matches \"Working From Home\".\n";
+            text += "`/c2s-whitelist set \"Working From Home\" :home:` - Show status as `Working From Home :home:` when event matches \"Working From Home\".\n";
+            text += "`/c2s-whitelist set \"Working From Home\" WFH` - Show status as `WFH` when event matches \"Working From Home\".\n";
+            text += "`/c2s-whitelist set \"Working From Home\" WFH :home:` - Show status as `WFH :home:` when event matches \"Working From Home\".\n";
+            text += "`/c2s-whitelist remove \"Working From Home\"` - Remove \"Working From Home\" entry.\n";
+            text += "\n";
+            text += "More detail at https://github.com/robhruska/CalendarToSlack/wiki";
+
+            _slack.PostSlackbotMessage(user.SlackApplicationAuthToken, user.SlackUserInfo, text);
+        }
+
         public void EchoWhitelistToSlackbot(string userId, bool withCommentary = true, string flashMessage = null)
         {
             var user = FindUserById(userId);

--- a/CalendarToSlack/UserDatabase.cs
+++ b/CalendarToSlack/UserDatabase.cs
@@ -360,9 +360,19 @@ namespace CalendarToSlack
         public void EchoWhitelistToSlackbot(string userId)
         {
             var user = FindUserById(userId);
-            var tokenString = GetTokenListForSlackbot(user.StatusMessageFilters);
-            var message = string.Format("Whitelist:\n{0}", tokenString);
-            _slack.PostSlackbotMessage(user.SlackApplicationAuthToken, user.SlackUserInfo, message);
+
+            // TODO implement
+            var text = "*Your default status is: :whiskeyrob: `Not yet implemented!`*\n";
+            text += "_This is used when you don't have an active calendar event. To change your default status, use_ `/c2s-default-status`\n\n";
+            text += "*Your whitelisted &amp; mapped statuses:*\n_If a calendar event name matches these, they'll be used as your Slack status. Matching events can be transformed to different Slack statuses (shown with `>`). If unmatched, a generic Slack status (e.g. \"Away\" or \"OOO\") will be used. Use `/c2s-whitelist` to manage this list._\n\n";
+            foreach (var filter in user.StatusMessageFilters.OrderBy(filter => filter.Key))
+            {
+                var emoji = (string.IsNullOrWhiteSpace(filter.Value.StatusEmoji) ? ":transparent:" : filter.Value.StatusEmoji);
+                var mapping = (filter.Key == filter.Value.StatusText ? "" : $" uses status `{filter.Value.StatusText}`");
+                text += $"{emoji} `{filter.Key}`{mapping}\n";
+            }
+            
+            _slack.PostSlackbotMessage(user.SlackApplicationAuthToken, user.SlackUserInfo, text);
         }
 
         private RegisteredUser FindUserById(string userId)


### PR DESCRIPTION
* More user-friendly syntax
* Support for strings with spaces (by using double quotes)
* Better formatting on slackbot messages

The general syntax is now `/c2s-whitelist <operation> <calendar-event-matching-string> <what-should-be-shown-in-slack> <emoji>`. Examples:

```
/c2s-whitelist set "Working From Home"
/c2s-whitelist set "Working From Home" :home:
/c2s-whitelist set "Working From Home" "WFH"
/c2s-whitelist set "Working From Home" "WFH" :home:
/c2s-whitelist set Plan
/c2s-whitelist set Plan :calendar:
/c2s-whitelist set Plan Meeting
/c2s-whitelist set Plan Meeting :calendar:
/c2s-whitelist remove "Working From Home"
/c2s-whitelist remove Plan
```