### PR TITLE
Implement default status APIs in DB text file

### DIFF
--- a/CalendarToSlack/CalendarToSlack.csproj
+++ b/CalendarToSlack/CalendarToSlack.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Slack.cs" />
     <Compile Include="SlackCommandConsumer.cs" />
+    <Compile Include="StatusConstants.cs" />
     <Compile Include="Updater.cs" />
     <Compile Include="UserDatabase.cs" />
   </ItemGroup>

--- a/CalendarToSlack/Slack.cs
+++ b/CalendarToSlack/Slack.cs
@@ -136,9 +136,13 @@ namespace CalendarToSlack
                 return;
             }
 
-            var profile = $"{{\"status_text\":\"{status.StatusText}\",\"status_emoji\":\"{status.StatusEmoji}\"}}";
+            // If no text is specified in a user's default status in the DB, it will default to [default] -- so change
+            // to an empty string for Slack
+            var statusText = status.StatusText != StatusConstants.DefaultStatus ? status.StatusText : "";
 
-            Log.Info($"Changed profile status text to {status.StatusText} and emoji to {status.StatusEmoji}");
+            var profile = $"{{\"status_text\":\"{statusText}\",\"status_emoji\":\"{status.StatusEmoji}\"}}";
+
+            Log.Info($"Changed profile status text to {statusText} and emoji to {status.StatusEmoji}");
             
             var content = new FormUrlEncodedContent(new Dictionary<string, string>
             {
@@ -182,20 +186,6 @@ namespace CalendarToSlack
                     Email = member.profile.email
                 };
 
-                // startup presence = member.presence
-                // 
-                // This assumes that the custom status of the user at startup is their desired default, 
-                // but if the app starts when the user has a meeting or OOO-related status set, that will be
-                // used as the default. TODO: add manual default status setting: https://github.com/robhruska/CalendarToSlack/issues/17
-                if (member.profile.status_emoji != ":spiral_calendar_pad:")
-                {
-                    slackUserInfo.DefaultCustomStatus = new CustomStatus
-                    {
-                        StatusText = member.profile.status_text,
-                        StatusEmoji = member.profile.status_emoji
-                    };
-                }
-
                 results.Add(slackUserInfo);
             }
             return results;
@@ -230,8 +220,6 @@ namespace CalendarToSlack
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public string Email { get; set; }
-
-        public CustomStatus DefaultCustomStatus { get; set; }
     }
 
     class CustomStatus

--- a/CalendarToSlack/SlackCommandConsumer.cs
+++ b/CalendarToSlack/SlackCommandConsumer.cs
@@ -207,29 +207,9 @@ namespace CalendarToSlack
                 // /c2s-whitelist set Plan Meeting :calendar:
                 if (subcommand.Equals("set", StringComparison.OrdinalIgnoreCase))
                 {
-                    if (args.Count == 0) return;
+                    if (args.Count == 0 || args.Any(ContainsIllegalCharacters)) return;
 
-                    if (args.Any(ContainsIllegalCharacters)) return;
-
-                    var token = args[0];
-                    
-                    if (args.Count == 2)
-                    {
-                        if (IsEmoji(args[1]))
-                        {
-                            token += $";{args[1]}";
-                        }
-                        else
-                        {
-                            token += $">{args[1]}";
-                        }
-                    }
-                    else if (args.Count >= 3)
-                    {
-                        token += $">{args[1]};{args[2]}";
-                    }
-
-                    _userdb.AddToWhitelist(userId, token);
+                    _userdb.AddToWhitelist(userId, TokenizeArgs(args[0], args.GetRange(1, 2)));
                     return;
                 }
 
@@ -237,9 +217,7 @@ namespace CalendarToSlack
                 // /c2s-whitelist remove NSS
                 if (subcommand.Equals("remove", StringComparison.OrdinalIgnoreCase))
                 {
-                    if (args.Count == 0) return;
-
-                    if (args.Any(ContainsIllegalCharacters)) return;
+                    if (args.Count == 0 || args.Any(ContainsIllegalCharacters)) return;
 
                     var token = args[0];
                     _userdb.RemoveFromWhitelist(userId, token);
@@ -252,19 +230,41 @@ namespace CalendarToSlack
                 // /c2s-whitelist set-default "Project Marvel" :marvel:
                 if (subcommand.Equals("set-default", StringComparison.OrdinalIgnoreCase))
                 {
-                    // TODO implement
+                    if (args.Count == 0 || args.Any(ContainsIllegalCharacters)) return;
+
+                    _userdb.AddToWhitelist(userId, TokenizeArgs(StatusConstants.DefaultStatus, args));
                     return;
                 }
 
                 // /c2s-whitelist remove-default
                 if (subcommand.Equals("remove-default", StringComparison.OrdinalIgnoreCase))
                 {
-                    // TODO implement
+                    _userdb.RemoveFromWhitelist(userId, StatusConstants.DefaultStatus);
                     return;
                 }
             }
 
             Log.ErrorFormat("Unrecognized slash command {0} from user {1}", command, userId);
+        }
+
+        private static string TokenizeArgs(string token, List<string> args)
+        {
+            if (args.Count == 1)
+            {
+                if (IsEmoji(args[0]))
+                {
+                    token += $";{args[0]}";
+                }
+                else
+                {
+                    token += $">{args[0]}";
+                }
+            }
+            else if (args.Count > 1)
+            {
+                token += $">{args[0]};{args[1]}";
+            }
+            return token;
         }
 
         private static bool IsEmoji(string arg)
@@ -278,7 +278,11 @@ namespace CalendarToSlack
         {
             if (string.IsNullOrWhiteSpace(arg)) return false;
 
-            return arg.Contains(";") || arg.Contains(">") || arg.Contains("|");
+            return arg.Contains(";") 
+                || arg.Contains(">") 
+                || arg.Contains("|") 
+                || arg.Contains("[") 
+                || arg.Contains("]");
         }
     }
 }

--- a/CalendarToSlack/SlackCommandConsumer.cs
+++ b/CalendarToSlack/SlackCommandConsumer.cs
@@ -209,7 +209,7 @@ namespace CalendarToSlack
                 {
                     if (args.Count == 0 || args.Any(ContainsIllegalCharacters)) return;
 
-                    _userdb.AddToWhitelist(userId, TokenizeArgs(args[0], args.GetRange(1, 2)));
+                    _userdb.AddToWhitelist(userId, TokenizeArgs(args[0], args.Skip(1).ToList()));
                     return;
                 }
 
@@ -219,8 +219,7 @@ namespace CalendarToSlack
                 {
                     if (args.Count == 0 || args.Any(ContainsIllegalCharacters)) return;
 
-                    var token = args[0];
-                    _userdb.RemoveFromWhitelist(userId, token);
+                    _userdb.RemoveFromWhitelist(userId, args[0]);
                     return;
                 }
 
@@ -249,6 +248,8 @@ namespace CalendarToSlack
 
         private static string TokenizeArgs(string token, List<string> args)
         {
+            if (!args.Any()) return token;
+
             if (args.Count == 1)
             {
                 if (IsEmoji(args[0]))
@@ -264,6 +265,7 @@ namespace CalendarToSlack
             {
                 token += $">{args[0]};{args[1]}";
             }
+
             return token;
         }
 

--- a/CalendarToSlack/StatusConstants.cs
+++ b/CalendarToSlack/StatusConstants.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CalendarToSlack
+{
+    public static class StatusConstants
+    {
+        public static readonly string DefaultStatus = "[default]";
+    }
+}

--- a/CalendarToSlack/Updater.cs
+++ b/CalendarToSlack/Updater.cs
@@ -184,7 +184,7 @@ namespace CalendarToSlack
                     message = $"{message} after your whitelist was updated";
                 }
 
-                MakeSlackApiCalls(user, Presence.Auto, user.SlackUserInfo.DefaultCustomStatus, message, null);
+                MakeSlackApiCalls(user, Presence.Auto, user.DefaultCustomStatus, message, null);
                 return;
             }
 

--- a/CalendarToSlack/UserDatabase.cs
+++ b/CalendarToSlack/UserDatabase.cs
@@ -421,7 +421,11 @@ namespace CalendarToSlack
 
         public string SlackApplicationAuthToken { get; set; }
         public Dictionary<string, CustomStatus> StatusMessageFilters { get; set; }
-        public HashSet<Option> Options { get; set; } 
+        public HashSet<Option> Options { get; set; }
+
+        public CustomStatus DefaultCustomStatus => StatusMessageFilters.ContainsKey(StatusConstants.DefaultStatus)
+            ? StatusMessageFilters[StatusConstants.DefaultStatus]
+            : new CustomStatus {StatusText = "", StatusEmoji = ""};
 
         // These fields aren't persisted, but get set/modified during runtime.
 


### PR DESCRIPTION
SQLite might take a while to implement, and default statuses are painful right now. This implements a rudimentary default status approach in the text file that just uses a distinct token, `[default]`, as the key for the filter. It also implements `/c2s-whitelist set-default` and `/c2s-whitelist remove-default`.